### PR TITLE
Adding open graph tags to rssitemcontent pages

### DIFF
--- a/_generator/site-generator/index.js
+++ b/_generator/site-generator/index.js
@@ -28,6 +28,7 @@ module.exports = function writeFilesFromComicObjects(comicObjects, supporters) {
 			var filename = '../../rssitemcontent/' + comicStrip.date + '/' + uniqueString + '.html'
 			renderAndWrite(filename, 'rssitemcontent', {
 				comicName: comicObject.basename,
+				urlFileName: uniqueString + '.html',
 				comicStrip: comicStrip
 			})
 		})

--- a/_generator/site-generator/template/rssitemcontent-template.html
+++ b/_generator/site-generator/template/rssitemcontent-template.html
@@ -1,8 +1,19 @@
-<p>
-	<img src="{{comicStrip.comicImageUrl}}" alt="{{comicStrip.titleAuthorDate}}" title="{{comicStrip.titleAuthorDate}}">
-</p>
-<p>
-	<a href="{{comicStrip.url}}">Source</a> -
-	<a href="https://www.comicsrss.com/preview/{{encodeURI(comicName)}}">Comics RSS</a> -
-	<a href="https://www.patreon.com/bePatron?u=6855838">Patreon</a>
-</p>
+<html>
+	<head>
+		<title>{{comicStrip.titleAuthorDate}}</title>
+		<meta property="og:title" content="{{comicStrip.titleAuthorDate}}" />
+		<meta property="og:type" content="article" />
+		<meta property="og:url" content="https://www.comicsrss.com/rssitemcontent/{{comicStrip.date}}/" />
+		<meta property="og:image" content="{{comicStrip.comicImageUrl}}" />
+	</head>
+	<body>	
+		<p>
+			<img src="{{comicStrip.comicImageUrl}}" alt="{{comicStrip.titleAuthorDate}}" title="{{comicStrip.titleAuthorDate}}">
+		</p>
+		<p>
+			<a href="{{comicStrip.url}}">Source</a> -
+			<a href="https://www.comicsrss.com/preview/{{encodeURI(comicName)}}">Comics RSS</a> -
+			<a href="https://www.patreon.com/bePatron?u=6855838">Patreon</a>
+		</p>
+	</body>
+</html>

--- a/_generator/site-generator/template/rssitemcontent-template.html
+++ b/_generator/site-generator/template/rssitemcontent-template.html
@@ -3,7 +3,7 @@
 		<title>{{comicStrip.titleAuthorDate}}</title>
 		<meta property="og:title" content="{{comicStrip.titleAuthorDate}}" />
 		<meta property="og:type" content="article" />
-		<meta property="og:url" content="https://www.comicsrss.com/rssitemcontent/{{comicStrip.date}}/" />
+		<meta property="og:url" content="https://www.comicsrss.com/rssitemcontent/{{comicStrip.date}}/{{urlFileName}}" />
 		<meta property="og:image" content="{{comicStrip.comicImageUrl}}" />
 	</head>
 	<body>	


### PR DESCRIPTION
Hey,

This is just a little pull request to add [open graph metadata](http://ogp.me/) to the rssitemcontent pages, along with adding html, head, and body tags.

This should mean that new comic page links will have nice previews when viewed in other apps

How does this look?