### PR TITLE
keep minimum strip count 

### DIFF
--- a/_generator/bin.js
+++ b/_generator/bin.js
@@ -9,6 +9,7 @@ const defaultScrapers = [
 ]
 const expirationDays = 90
 const expirationCount = 50
+const minimumCount = 10
 
 function migration([ id, seriesObject ]) {
 	// seriesObject.strips = seriesObject.strips.filter(s => s.date !== null && s.date.slice(7) !== '2020-09') // bye bye all this month
@@ -128,7 +129,7 @@ async function runScraper(scraperName) {
 	const verifiedSeriesObjects = objMapValue(newSeriesObjects, newSeriesObject => {
 		const strips = newSeriesObject.strips
 			.map(({ url, date, imageUrl }) => ({ url, date, imageUrl }))
-			.filter((strip, i) => (i === 0 || new Date(strip.date) > expirationDate)) // keeps recent strips
+			.filter((strip, i) => ((i >= 0 && i < minimumCount) || new Date(strip.date) > expirationDate)) // keeps recent strips
 			.slice(0, expirationCount)
 		return strips ? { ...newSeriesObject, strips } : null
 	})


### PR DESCRIPTION
Potential fix for #153

Since these are all old strips that aren't being updated, they are never more recent than `expirationDate`, which means only the first strip is kept:
```javascript
.filter((strip, i) => (i === 0 || new Date(strip.date) > expirationDate)) // keeps recent strips
```

To mitigate this I added a `minimumCount` variable that applies globally, but this could also be moved to a per-scraper value.

Not sure what the other options are since these aren't being updated, but if there's still a desire to see some in the feed then this is probably the best compromise.

----

https://github.com/ArtskydJ/comicsrss.com/blob/8aecc970c5f7834d353f187b1068cb50a4223dbb/_generator/bin.js#L128-L134